### PR TITLE
[FIX] stock_analytic: Fix de cantidades negativas en apuntes analíticos

### DIFF
--- a/stock_analytic/models/__init__.py
+++ b/stock_analytic/models/__init__.py
@@ -4,3 +4,4 @@ from . import analytic_applicability
 from . import stock_move
 from . import stock_picking
 from . import stock_scrap
+from . import account_move_line

--- a/stock_analytic/models/account_move_line.py
+++ b/stock_analytic/models/account_move_line.py
@@ -10,17 +10,7 @@ class AccountMoveLine(models.Model):
         # FIX TRESCLOUD: Arreglo en la creación de apuntes analíticos para que la cantidad sea positiva
         # Los apuntes analíticos siempre deben ser positivas y en el caso de que se creen a partir de un movimiento de salida o de desecho, la cantidad debe ser positiva
         vals = super()._prepare_analytic_distribution_line(distribution, account_id, distribution_on_each_plan)
-        company = self.company_id
 
-        # Validamos que el apunte analítico a crear sea de una compañía ecuatoriana
-        is_ec_analytic_line = company and company.account_fiscal_country_id.code == 'EC'
-
-        # Validamos que la cuenta analítica a crear sea de los diarios de inventario y que la cantidad sea negativa
-        stock_journals = self.env['product.category'].with_company(company).search([('property_stock_journal', '!=', False)]).mapped('property_stock_journal')
-        journal = self.journal_id
-
-        if is_ec_analytic_line and \
-            journal.id in stock_journals.ids and \
-            self.quantity < 0:
+        if self.quantity < 0:
             vals.update({'unit_amount': abs(self.quantity)})
         return vals

--- a/stock_analytic/models/account_move_line.py
+++ b/stock_analytic/models/account_move_line.py
@@ -7,8 +7,7 @@ class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'    
 
     def _prepare_analytic_distribution_line(self, distribution, account_id, distribution_on_each_plan):
-        # FIX TRESCLOUD: Arreglo en la creación de apuntes analíticos para que la cantidad sea positiva
-        # Los apuntes analíticos siempre deben ser positivas y en el caso de que se creen a partir de un movimiento de salida o de desecho, la cantidad debe ser positiva
+        # Los apuntes analíticos siempre deben ser positivas y más aún casos en que se creen a partir de un movimiento de salida o de desecho, donde su cantidad es negativa
         vals = super()._prepare_analytic_distribution_line(distribution, account_id, distribution_on_each_plan)
 
         if self.quantity < 0:

--- a/stock_analytic/models/account_move_line.py
+++ b/stock_analytic/models/account_move_line.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields, api
+from odoo.exceptions import UserError, ValidationError
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'    
+
+    def _prepare_analytic_distribution_line(self, distribution, account_id, distribution_on_each_plan):
+        # FIX TRESCLOUD: Arreglo en la creación de apuntes analíticos para que la cantidad sea positiva
+        # Los apuntes analíticos siempre deben ser positivas y en el caso de que se creen a partir de un movimiento de salida o de desecho, la cantidad debe ser positiva
+        vals = super()._prepare_analytic_distribution_line(distribution, account_id, distribution_on_each_plan)
+        company = self.company_id
+
+        # Validamos que el apunte analítico a crear sea de una compañía ecuatoriana
+        is_ec_analytic_line = company and company.account_fiscal_country_id.code == 'EC'
+
+        # Validamos que la cuenta analítica a crear sea de los diarios de inventario y que la cantidad sea negativa
+        stock_journals = self.env['product.category'].with_company(company).search([('property_stock_journal', '!=', False)]).mapped('property_stock_journal')
+        journal = self.journal_id
+
+        if is_ec_analytic_line and \
+            journal.id in stock_journals.ids and \
+            self.quantity < 0:
+            vals.update({'unit_amount': abs(self.quantity)})
+        return vals

--- a/stock_analytic/models/account_move_line.py
+++ b/stock_analytic/models/account_move_line.py
@@ -11,5 +11,8 @@ class AccountMoveLine(models.Model):
         vals = super()._prepare_analytic_distribution_line(distribution, account_id, distribution_on_each_plan)
 
         if self.quantity < 0:
-            vals.update({'unit_amount': abs(self.quantity)})
+            # Validamos que la cuenta analítica a crear sea de los diarios de inventario para los productos que tienen ajustes de inventario y que la cantidad sea negativa
+            stock_journals = self.env['product.category'].with_company(self.company_id).search([('property_stock_journal', '!=', False)]).mapped('property_stock_journal')
+            if stock_journals and self.journal_id.id in stock_journals.ids:
+                vals.update({'unit_amount': abs(self.quantity)})
         return vals


### PR DESCRIPTION
- Se añade una solución a las cantidades negativas caundo se crea un apunte analìtico al momento de una transferencia de inventario de desecho o de salida de inventario. Nativamente el mixin de analíticas obtiene la información del apunte contable y el apunte contable obtiene la cantidad del movimiento, donde este movimiento tiene las cantidades negativas.